### PR TITLE
Add Reader interface

### DIFF
--- a/reader.go
+++ b/reader.go
@@ -2,19 +2,26 @@ package stream
 
 import "io"
 
-// Reader is a concurrent-safe Stream Reader.
-type Reader struct {
+type Reader interface {
+	Name() string
+	ReadAt(p []byte, off int64) (n int, err error)
+	Read(p []byte) (n int, err error)
+	Close() error
+}
+
+// StreamReader is a concurrent-safe Stream Reader.
+type StreamReader struct {
 	s    *Stream
 	file File
 }
 
 // Name returns the name of the underlying File in the FileSystem.
-func (r *Reader) Name() string { return r.file.Name() }
+func (r *StreamReader) Name() string { return r.file.Name() }
 
 // ReadAt lets you Read from specific offsets in the Stream.
 // ReadAt blocks while waiting for the requested section of the Stream to be written,
 // unless the Stream is closed in which case it will always return immediately.
-func (r *Reader) ReadAt(p []byte, off int64) (n int, err error) {
+func (r *StreamReader) ReadAt(p []byte, off int64) (n int, err error) {
 	r.s.b.RLock()
 	defer r.s.b.RUnlock()
 
@@ -45,7 +52,7 @@ func (r *Reader) ReadAt(p []byte, off int64) (n int, err error) {
 
 // Read reads from the Stream. If the end of an open Stream is reached, Read
 // blocks until more data is written or the Stream is Closed.
-func (r *Reader) Read(p []byte) (n int, err error) {
+func (r *StreamReader) Read(p []byte) (n int, err error) {
 	r.s.b.RLock()
 	defer r.s.b.RUnlock()
 
@@ -76,7 +83,7 @@ func (r *Reader) Read(p []byte) (n int, err error) {
 
 // Close closes this Reader on the Stream. This must be called when done with the
 // Reader or else the Stream cannot be Removed.
-func (r *Reader) Close() error {
+func (r *StreamReader) Close() error {
 	defer r.s.dec()
 	return r.file.Close()
 }

--- a/stream.go
+++ b/stream.go
@@ -69,7 +69,7 @@ func (s *Stream) Remove() error {
 // NextReader will return a concurrent-safe Reader for this stream. Each Reader will
 // see a complete and independent view of the stream, and can Read will the stream
 // is written to.
-func (s *Stream) NextReader() (*Reader, error) {
+func (s *Stream) NextReader() (Reader, error) {
 	s.inc()
 
 	select {
@@ -85,7 +85,7 @@ func (s *Stream) NextReader() (*Reader, error) {
 		return nil, err
 	}
 
-	return &Reader{file: file, s: s}, nil
+	return &StreamReader{file: file, s: s}, nil
 }
 
 func (s *Stream) inc() { s.grp.Add(1) }


### PR DESCRIPTION
Needed an Interface for Reader to allow fscache to return stream.Reader in the get method `Get(key string) (stream.Reader, io.WriteCloser, error)`.

I'll probably push up the fscache changes later today once I've tested it a bit more. 
