### PR TITLE
Add Stream.Cancel()

### DIFF
--- a/reader.go
+++ b/reader.go
@@ -1,16 +1,25 @@
 package stream
 
 import (
+	"errors"
 	"io"
 	"sync"
 )
 
+// ErrRemoving is returned when reading a Reader on a Stream which is being Removed.
+var ErrCanceled = errors.New("reader has been canceled")
+
 // Reader is a concurrent-safe Stream Reader.
 type Reader struct {
-	s       *Stream
-	file    File
-	mu      sync.Mutex
-	readOff int64
+	id       int64
+	s        *Stream
+	file     File
+	mu       sync.Mutex
+	readOff  int64
+	close    bool
+	cancel   bool
+	closing  bool
+	closeErr error
 }
 
 // Name returns the name of the underlying File in the FileSystem.
@@ -20,9 +29,19 @@ func (r *Reader) Name() string { return r.file.Name() }
 // ReadAt blocks while waiting for the requested section of the Stream to be written,
 // unless the Stream is closed in which case it will always return immediately.
 func (r *Reader) ReadAt(p []byte, off int64) (n int, err error) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
 	var m int
 
 	for {
+		if r.cancel {
+			return 0, ErrCanceled
+		}
+
+		if r.closing {
+			return 0, nil
+		}
 
 		m, err = r.file.ReadAt(p[n:], off)
 		n += m
@@ -32,8 +51,15 @@ func (r *Reader) ReadAt(p []byte, off int64) (n int, err error) {
 		case n != 0 && err == nil:
 			return n, err
 		case err == io.EOF:
-			if v, open := r.s.b.Wait(off); v == 0 && !open {
-				return n, io.EOF
+			if v, open, canceled := r.s.b.Wait(off, r.id); v == 0 {
+				if canceled || r.cancel {
+					r.cancel = true
+					r.closeUnsafe()
+					return 0, ErrCanceled
+				} else if !open || r.close {
+					r.closeUnsafe()
+					return n, io.EOF
+				}
 			}
 		case err != nil:
 			return n, err
@@ -47,9 +73,18 @@ func (r *Reader) ReadAt(p []byte, off int64) (n int, err error) {
 func (r *Reader) Read(p []byte) (n int, err error) {
 	r.mu.Lock()
 	defer r.mu.Unlock()
+
 	var m int
 
 	for {
+		if r.cancel {
+			return 0, ErrCanceled
+		}
+
+		if r.closing {
+			return 0, io.EOF
+		}
+
 		m, err = r.file.Read(p[n:])
 		n += m
 		r.readOff += int64(m)
@@ -58,8 +93,15 @@ func (r *Reader) Read(p []byte) (n int, err error) {
 		case n != 0 && err == nil:
 			return n, nil
 		case err == io.EOF:
-			if v, open := r.s.b.Wait(r.readOff); v == 0 && !open {
-				return n, io.EOF
+			if v, open, canceled := r.s.b.Wait(r.readOff, r.id); v == 0 {
+				if canceled || r.cancel {
+					r.cancel = true
+					r.closeUnsafe()
+					return 0, ErrCanceled
+				} else if !open || r.close {
+					r.closeUnsafe()
+					return n, io.EOF
+				}
 			}
 		case err != nil:
 			return n, err
@@ -70,8 +112,33 @@ func (r *Reader) Read(p []byte) (n int, err error) {
 // Close closes this Reader on the Stream. This must be called when done with the
 // Reader or else the Stream cannot be Removed.
 func (r *Reader) Close() error {
+	r.close = true
+	r.s.b.Unblock(r.id)
+	r.mu.Lock()
+	r.mu.Unlock()
+	return r.closeUnsafe()
+}
+
+// Cancel closes this Reader on the Stream and fails next reads from reader.
+// It immediately cancels all pending reads
+func (r *Reader) Cancel() error {
+	r.cancel = true
+	r.s.b.Unblock(r.id)
+	r.mu.Lock()
+	r.mu.Unlock()
+	return r.closeUnsafe()
+}
+
+// This should be called inside r.mu.Lock()
+func (r *Reader) closeUnsafe() error {
+	if r.closing {
+		return r.closeErr
+	}
+	r.closing = true
 	defer r.s.dec()
-	return r.file.Close()
+	r.closeErr = r.file.Close()
+	r.s.b.Closed(r.id)
+	return r.closeErr
 }
 
 // Size returns the current size of the entire stream (not the remaining bytes to be read),

--- a/stream.go
+++ b/stream.go
@@ -3,20 +3,25 @@ package stream
 
 import (
 	"errors"
+	"math/rand"
 	"sync"
 )
 
 // ErrRemoving is returned when requesting a Reader on a Stream which is being Removed.
 var ErrRemoving = errors.New("cannot open a new reader while removing file")
+var ErrCanceling = errors.New("cannot open a new reader while canceling stream")
+var ErrWriteAfterClosing = errors.New("cannot write to stream after closing file")
 
 // Stream is used to concurrently Write and Read from a File.
 type Stream struct {
-	mu       sync.Mutex
-	grp      sync.WaitGroup
-	b        *broadcaster
-	file     File
-	fs       FileSystem
-	removing chan struct{}
+	mu        sync.Mutex
+	grp       sync.WaitGroup
+	b         *broadcaster
+	file      File
+	fs        FileSystem
+	canceling bool
+	removing  bool
+	closing   bool
 }
 
 // New creates a new Stream from the StdFileSystem with Name "name".
@@ -28,10 +33,9 @@ func New(name string) (*Stream, error) {
 func NewStream(name string, fs FileSystem) (*Stream, error) {
 	f, err := fs.Create(name)
 	sf := &Stream{
-		file:     f,
-		fs:       fs,
-		b:        newBroadcaster(),
-		removing: make(chan struct{}),
+		file: f,
+		fs:   fs,
+		b:    newBroadcaster(),
 	}
 	sf.inc()
 	return sf, err
@@ -43,10 +47,9 @@ func NewStream(name string, fs FileSystem) (*Stream, error) {
 func NewMemStream() *Stream {
 	f := newMemFile("")
 	s := &Stream{
-		file:     f,
-		fs:       singletonFs{f},
-		b:        newBroadcaster(),
-		removing: make(chan struct{}),
+		file: f,
+		fs:   singletonFs{f},
+		b:    newBroadcaster(),
 	}
 	s.inc()
 	return s
@@ -67,31 +70,88 @@ func (s *Stream) Name() string { return s.file.Name() }
 
 // Write writes p to the Stream. It's concurrent safe to be called with Stream's other methods.
 func (s *Stream) Write(p []byte) (int, error) {
-	s.mu.Lock()
-	defer s.mu.Unlock()
+	if s.closing {
+		return 0, ErrWriteAfterClosing
+	}
 	n, err := s.file.Write(p)
 	s.b.Wrote(n)
 	return n, err
 }
 
+func (s *Stream) performClose(canceling bool) error {
+	if s.closing {
+		return nil
+	}
+	s.closing = true
+	err := s.file.Close()
+	if err != nil {
+		s.closing = false
+		return err
+	}
+	s.b.Close(canceling)
+	s.dec()
+	return nil
+}
+
 // Close will close the active stream. This will cause Readers to return EOF once they have
 // read the entire stream.
 func (s *Stream) Close() error {
+	// If stream is removing then lock is already acquired by remove and remove is waiting for close
+	if s.removing {
+		return s.performClose(false)
+	}
 	s.mu.Lock()
 	defer s.mu.Unlock()
-	err := s.file.Close()
-	s.b.Close()
-	s.dec()
-	return err
+	return s.performClose(false)
 }
 
 // Remove will block until the Stream and all its Readers have been Closed,
 // at which point it will delete the underlying file. NextReader() will return
 // ErrRemoving if called after Remove.
 func (s *Stream) Remove() error {
-	close(s.removing)
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if s.canceling {
+		return nil
+	}
+	return s.remove()
+}
+
+// This should be called inside s.mu.Lock()
+func (s *Stream) remove() error {
+	if s.removing {
+		return nil
+	}
+	s.removing = true
 	s.grp.Wait()
-	return s.fs.Remove(s.file.Name())
+	if err := s.fs.Remove(s.file.Name()); err != nil {
+		s.removing = false
+		return err
+	}
+	return nil
+}
+
+// Cancel will close Stream and all it's Readers
+// at which point it will delete the underlying file.
+// NextReader() will return ErrCanceling if canceling.
+func (s *Stream) Cancel() error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if s.canceling {
+		return nil
+	}
+	s.canceling = true
+	if err := s.performClose(true); err != nil {
+		s.canceling = false
+		return err
+	}
+	if err := s.remove(); err != nil {
+		s.canceling = false
+		return err
+	}
+	return nil
 }
 
 // NextReader will return a concurrent-safe Reader for this stream. Each Reader will
@@ -100,11 +160,14 @@ func (s *Stream) Remove() error {
 func (s *Stream) NextReader() (*Reader, error) {
 	s.inc()
 
-	select {
-	case <-s.removing:
+	if s.canceling {
+		s.dec()
+		return nil, ErrCanceling
+	}
+
+	if s.removing {
 		s.dec()
 		return nil, ErrRemoving
-	default:
 	}
 
 	file, err := s.fs.Open(s.file.Name())
@@ -113,7 +176,7 @@ func (s *Stream) NextReader() (*Reader, error) {
 		return nil, err
 	}
 
-	return &Reader{file: file, s: s}, nil
+	return &Reader{file: file, s: s, id: rand.Int63()}, nil
 }
 
 func (s *Stream) inc() { s.grp.Add(1) }

--- a/sync.go
+++ b/sync.go
@@ -5,26 +5,30 @@ import (
 )
 
 type broadcaster struct {
-	mu     sync.RWMutex
-	cond   *sync.Cond
-	closed bool
-	size   int64
+	mu        sync.RWMutex
+	cond      *sync.Cond
+	closed    bool
+	canceled  bool
+	size      int64
+	unblocked map[int64]bool
 }
 
 func newBroadcaster() *broadcaster {
 	var b broadcaster
 	b.cond = sync.NewCond(b.mu.RLocker())
+	b.unblocked = make(map[int64]bool)
 	return &b
 }
 
 // Wait blocks until we've written past the given offset, or until closed.
-func (b *broadcaster) Wait(off int64) (n int64, open bool) {
+func (b *broadcaster) Wait(off int64, id int64) (n int64, open bool, canceled bool) {
 	b.mu.RLock()
 	defer b.mu.RUnlock()
-	for !b.closed && off >= b.size {
+
+	for !b.closed && off >= b.size && !b.unblocked[id] {
 		b.cond.Wait()
 	}
-	return b.size - off, !b.closed
+	return b.size - off, !b.closed, b.canceled
 }
 
 func (b *broadcaster) Wrote(n int) {
@@ -36,9 +40,23 @@ func (b *broadcaster) Wrote(n int) {
 	}
 }
 
-func (b *broadcaster) Close() error {
+func (b *broadcaster) Unblock(id int64) {
+	b.mu.Lock()
+	b.unblocked[id] = true
+	b.mu.Unlock()
+	b.cond.Broadcast()
+}
+
+func (b *broadcaster) Closed(id int64) {
+	b.mu.Lock()
+	delete(b.unblocked, id)
+	b.mu.Unlock()
+}
+
+func (b *broadcaster) Close(canceled bool) error {
 	b.mu.Lock()
 	b.closed = true
+	b.canceled = canceled
 	b.mu.Unlock()
 	b.cond.Broadcast()
 	return nil


### PR DESCRIPTION
This PR adds ability to run Remove before Cancel, effectively cancelling streaming transfer.

This is so to support cancelling of streaming (i.e. notifying readers that write was closed prematurely), and they should not interpret their result as complete byte stream.

So:
- stream.Close()
  - writing is successful
  - reads are successful
- stream.Close() then stream.Remove()
  - writing is successful
  - reads succeed between close and remove but fail after remove (still require manual .Close())
- stream.Remove() then stream.Write() then
  - writing is failure
  - reads fail with err (but still require manual .Close())
  
  