### PR TITLE
Relax File interface requirements

### DIFF
--- a/fs.go
+++ b/fs.go
@@ -7,11 +7,10 @@ import (
 
 // File is a backing data-source for a Stream.
 type File interface {
-	Name() string // The name used to Create/Open the File
-	io.Reader     // Reader must continue reading after EOF on subsequent calls after more Writes.
-	io.ReaderAt   // Similarly to Reader
-	io.Writer     // Concurrent reading/writing must be supported.
-	io.Closer     // Close should do any cleanup when done with the File.
+	io.Reader   // Reader must continue reading after EOF on subsequent calls after more Writes.
+	io.ReaderAt // Similarly to Reader
+	io.Writer   // Concurrent reading/writing must be supported.
+	io.Closer   // Close should do any cleanup when done with the File.
 }
 
 // FileSystem is used to manage Files

--- a/memfs.go
+++ b/memfs.go
@@ -27,15 +27,14 @@ func NewMemFS() FileSystem {
 func (fs *memfs) Create(key string) (File, error) {
 	fs.mu.Lock()
 	defer fs.mu.Unlock()
-	file := newMemFile(key)
+	file := newMemFile()
 	fs.files[key] = file
 	return file, nil
 }
 
-func newMemFile(name string) *memFile {
+func newMemFile() *memFile {
 	file := &memFile{
-		name: name,
-		r:    bytes.NewBuffer(nil),
+		r: bytes.NewBuffer(nil),
 	}
 	file.buf.Store([]byte(nil))
 	file.memReader.memFile = file

--- a/reader.go
+++ b/reader.go
@@ -16,7 +16,7 @@ type Reader struct {
 }
 
 // Name returns the name of the underlying File in the FileSystem.
-func (r *Reader) Name() string { return r.file.Name() }
+func (r *Reader) Name() string { return r.s.name }
 
 // ReadAt lets you Read from specific offsets in the Stream.
 // ReadAt blocks while waiting for the requested section of the Stream to be written,

--- a/stream.go
+++ b/stream.go
@@ -16,6 +16,7 @@ type Stream struct {
 	file      File
 	fs        FileSystem
 	closeOnce onceWithErr
+	name      string
 }
 
 // New creates a new Stream from the StdFileSystem with Name "name".
@@ -26,19 +27,20 @@ func New(name string) (*Stream, error) {
 // NewStream creates a new Stream with Name "name" in FileSystem fs.
 func NewStream(name string, fs FileSystem) (*Stream, error) {
 	f, err := fs.Create(name)
-	return newStream(f, fs), err
+	return newStream(name, f, fs), err
 }
 
 // NewMemStream creates an in-memory stream with no name, and no underlying fs.
 // This should replace uses of NewStream("name", NewMemFs()).
 // Remove() is unsupported as there is no fs to remove it from.
 func NewMemStream() *Stream {
-	f := newMemFile("")
-	return newStream(f, singletonFs{f})
+	f := newMemFile()
+	return newStream("", f, singletonFs{f})
 }
 
-func newStream(file File, fs FileSystem) *Stream {
+func newStream(name string, file File, fs FileSystem) *Stream {
 	return &Stream{
+		name: name,
 		file: file,
 		fs:   fs,
 		b:    newBroadcaster(),
@@ -56,7 +58,7 @@ func (fs singletonFs) Open(key string) (File, error) { return &memReader{memFile
 func (fs singletonFs) Remove(key string) error { return ErrUnsupported }
 
 // Name returns the name of the underlying File in the FileSystem.
-func (s *Stream) Name() string { return s.file.Name() }
+func (s *Stream) Name() string { return s.name }
 
 // Write writes p to the Stream. It's concurrent safe to be called with Stream's other methods.
 func (s *Stream) Write(p []byte) (int, error) {
@@ -84,7 +86,7 @@ func (s *Stream) Close() error {
 // ErrRemoving if called after Remove.
 func (s *Stream) Remove() error {
 	s.ShutdownWithErr(ErrRemoving)
-	return s.fs.Remove(s.file.Name())
+	return s.fs.Remove(s.name)
 }
 
 // ShutdownWithErr causes NextReader to stop creating new Readers and instead return err, this
@@ -109,7 +111,7 @@ func (s *Stream) Cancel() error {
 // is written to.
 func (s *Stream) NextReader() (*Reader, error) {
 	return s.b.NewReader(func() (*Reader, error) {
-		file, err := s.fs.Open(s.file.Name())
+		file, err := s.fs.Open(s.name)
 		if err != nil {
 			return nil, err
 		}

--- a/stream_test.go
+++ b/stream_test.go
@@ -46,7 +46,6 @@ type slowFile struct {
 	file File
 }
 
-func (r slowFile) Name() string { return r.file.Name() }
 func (r slowFile) Read(p []byte) (int, error) {
 	time.Sleep(5 * time.Millisecond)
 	return r.file.Read(p)


### PR DESCRIPTION
This PR removes the requirement of File to implement Name() method.

Reasons:
1. Name doesn't always makes any sense (e.g. memfs)
2. Prevents issues with implementation of fs.Name(), e.g. in my implementation I normalized relative path to absolute path and passed it to underlying os.Create(name). Then os.Name() returned absolute path what got passed to fs.Open() implementation that expected relative path on input and failed miserably. In principle name the result of Name() should be the same as passed to name of Create() or Open(), so it makes little sense for implementation to implement this method.
3. I cannot think of use case someone wanted to implement this method in custom way
4. It makes it easier to implement backend
5. This change is 100% backward compatible