### PR TITLE
if data is available, have Read return immediately on io.EOF

### DIFF
--- a/reader.go
+++ b/reader.go
@@ -46,7 +46,7 @@ func (r *Reader) read(p []byte, off *int64) (n int, err error) {
 		*off += int64(m)
 
 		switch {
-		case n != 0 && err == nil:
+		case n != 0 && (err == nil || err == io.EOF):
 			return n, nil
 
 		case err == io.EOF:


### PR DESCRIPTION
io.Reader contract allows for returning io.EOF and n > 0.  This change checks for that case, so  consumers of that reader have access to that data immediately.  The next call to Read will block.