### PR TITLE
Add CancelWithErr mechanism

### DIFF
--- a/djherbis-stream.iml
+++ b/djherbis-stream.iml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<module type="WEB_MODULE" version="4">
+  <component name="Go" enabled="true" />
+  <component name="NewModuleRootManager" inherit-compiler-output="true">
+    <exclude-output />
+    <content url="file://$MODULE_DIR$" />
+    <orderEntry type="inheritedJdk" />
+    <orderEntry type="sourceFolder" forTests="false" />
+  </component>
+</module>

--- a/reader.go
+++ b/reader.go
@@ -61,10 +61,12 @@ func (r *Reader) read(p []byte, off *int64) (n int, err error) {
 }
 
 func (r *Reader) checkErr(err error) error {
-	switch err {
-	case ErrCanceled:
+	switch {
+	case err == ErrCanceled,
+		err != nil && err == r.s.b.err:
 		r.Close()
 	}
+
 	return err
 }
 

--- a/stream.go
+++ b/stream.go
@@ -125,6 +125,13 @@ func (s *Stream) Cancel() error {
 	return s.Close() // all writes are stopped
 }
 
+// CancelWithErr works like Stream.Cancel, but permits a custom error
+// to be returned.
+func (s *Stream) CancelWithErr(err error) error {
+	s.b.CancelWithErr(err) // all existing reads are canceled, no new reads will occur, all readers closed
+	return s.Close()       // all writes are stopped
+}
+
 // NextReader will return a concurrent-safe Reader for this stream. Each Reader will
 // see a complete and independent view of the stream, and can Read while the stream
 // is written to.


### PR DESCRIPTION
We already have a `Stream.ShutdownWithErr` mechanism, which propagates a custom error.

There's also a `Stream.Cancel` method. However, there should be a `Stream.CancelWithErr` method to allow propagation of a custom error.


For example, let's say I'm reading from an http response, and writing the bytes to a stream. If there's an error reading the response, I specifically want to `Cancel` the stream (as opposed to calling `Shutdown`). But, any clients of the stream will just receive a generic `ErrCanceled`, which is not super helpful. I want to be able to propagate the http error back to the stream clients.
